### PR TITLE
Refactor: modernize authentication module and add centralized tests

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -11,7 +11,7 @@ from ...services.auth import (
     create_refresh_token,
     decode_token,
     get_current_user,
-    hash_password,
+    hash_password_sync,
     invalidate_token,
     ldap_authenticate,
     verify_password,
@@ -32,7 +32,7 @@ MOCK_USERS = {
         "email": "admin@company.com",
         "display_name": "Admin User",
         "role": "admin",
-        "password_hash": hash_password("admin123"),
+        "password_hash": hash_password_sync("admin123"),
         "is_active": True,
     },
     "trader": {
@@ -40,13 +40,18 @@ MOCK_USERS = {
         "email": "trader@company.com",
         "display_name": "Jane Trader",
         "role": "trader",
-        "password_hash": hash_password("trader123"),
+        "password_hash": hash_password_sync("trader123"),
         "is_active": True,
     },
 }
 
 
-@router.post("/login", response_model=TokenResponse)
+@router.post(
+    "/login",
+    response_model=TokenResponse,
+    summary="Login user",
+    description="Authenticates a user via LDAP or local mock users and returns a JWT access token.",
+)
 async def login(request: LoginRequest):
     # Try LDAP first, fallback to mock users
     ldap_user = await ldap_authenticate(request.username, request.password)
@@ -60,7 +65,7 @@ async def login(request: LoginRequest):
         }
     elif request.username in MOCK_USERS:
         user_data = MOCK_USERS[request.username]
-        if not verify_password(request.password, user_data["password_hash"]):
+        if not await verify_password(request.password, user_data["password_hash"]):
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"
             )
@@ -79,7 +84,12 @@ async def login(request: LoginRequest):
     )
 
 
-@router.post("/refresh", response_model=TokenResponse)
+@router.post(
+    "/refresh",
+    response_model=TokenResponse,
+    summary="Refresh access token",
+    description="Generates a new access token using a valid refresh token.",
+)
 async def refresh_token(refresh_token: str):
     payload = decode_token(refresh_token)
     if payload.get("type") != "refresh":
@@ -105,7 +115,12 @@ async def refresh_token(refresh_token: str):
     )
 
 
-@router.get("/me", response_model=UserResponse)
+@router.get(
+    "/me",
+    response_model=UserResponse,
+    summary="Get current user",
+    description="Returns the profile details of the currently authenticated user.",
+)
 async def get_me(current_user: dict = Depends(get_current_user)):
     user_id = current_user["sub"]
     for u in MOCK_USERS.values():
@@ -121,7 +136,11 @@ async def get_me(current_user: dict = Depends(get_current_user)):
     raise HTTPException(status_code=404, detail="User not found")
 
 
-@router.post("/logout")
+@router.post(
+    "/logout",
+    summary="Logout user",
+    description="Invalidates the current JWT access token.",
+)
 async def logout(credentials: HTTPAuthorizationCredentials = Depends(security)):
-    invalidate_token(credentials.credentials)
+    await invalidate_token(credentials.credentials)
     return {"message": "Logged out successfully"}

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import UTC, datetime, timedelta
 
 import bcrypt
@@ -36,7 +37,7 @@ def decode_token(token: str) -> dict:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
 
 
-def invalidate_token(token: str) -> None:
+async def invalidate_token(token: str) -> None:
     """Add token to blacklist to invalidate it."""
     token_blacklist.add(token)
     # Clean up expired tokens periodically (simplified)
@@ -51,32 +52,41 @@ async def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(s
     return payload
 
 
-def hash_password(password: str) -> str:
+def hash_password_sync(password: str) -> str:
+    """Synchronous version for static initialization."""
     return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
 
 
-def verify_password(plain_password: str, hashed_password: str) -> bool:
+async def hash_password(password: str) -> str:
+    return await asyncio.to_thread(hash_password_sync, password)
+
+
+def verify_password_sync(plain_password: str, hashed_password: str) -> bool:
+    """Synchronous version of verify password."""
     return bcrypt.checkpw(plain_password.encode("utf-8"), hashed_password.encode("utf-8"))
 
 
-async def ldap_authenticate(username: str, password: str) -> dict | None:
-    """Authenticate against LDAP server. Returns user info dict or None."""
+async def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return await asyncio.to_thread(verify_password_sync, plain_password, hashed_password)
+
+
+def _ldap_authenticate_sync(username: str, password: str, settings_dict: dict) -> dict | None:
     try:
         from ldap3 import ALL, Connection, Server
 
-        server = Server(settings.LDAP_SERVER, get_info=ALL)
-        user_dn = settings.LDAP_USER_SEARCH_FILTER.format(username=username)
+        server = Server(settings_dict["LDAP_SERVER"], get_info=ALL)
+        user_dn = settings_dict["LDAP_USER_SEARCH_FILTER"].format(username=username)
 
         # Try to bind with user credentials
         conn = Connection(
             server,
-            user=f"{user_dn},{settings.LDAP_USER_SEARCH_BASE}",
+            user=f"{user_dn},{settings_dict['LDAP_USER_SEARCH_BASE']}",
             password=password,
             auto_bind=True,
         )
 
         conn.search(
-            settings.LDAP_USER_SEARCH_BASE,
+            settings_dict["LDAP_USER_SEARCH_BASE"],
             f"(uid={username})",
             attributes=["mail", "cn", "uid"],
         )
@@ -95,3 +105,13 @@ async def ldap_authenticate(username: str, password: str) -> dict | None:
         }
     except Exception:
         return None
+
+
+async def ldap_authenticate(username: str, password: str) -> dict | None:
+    """Authenticate against LDAP server. Returns user info dict or None."""
+    settings_dict = {
+        "LDAP_SERVER": settings.LDAP_SERVER,
+        "LDAP_USER_SEARCH_FILTER": settings.LDAP_USER_SEARCH_FILTER,
+        "LDAP_USER_SEARCH_BASE": settings.LDAP_USER_SEARCH_BASE,
+    }
+    return await asyncio.to_thread(_ldap_authenticate_sync, username, password, settings_dict)

--- a/backend/tests/api/routes/test_auth_routes.py
+++ b/backend/tests/api/routes/test_auth_routes.py
@@ -1,0 +1,77 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from app.main import app
+from app.api.routes.auth import TRADER_USER_ID
+
+@pytest.mark.asyncio
+async def test_login_success():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.post(
+            "/api/auth/login",
+            json={"username": "trader", "password": "trader123"},
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert "access_token" in data
+    assert "refresh_token" in data
+    assert data["token_type"] == "bearer"
+
+@pytest.mark.asyncio
+async def test_login_failure():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.post(
+            "/api/auth/login",
+            json={"username": "trader", "password": "wrong_password"},
+        )
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Invalid credentials"}
+
+@pytest.mark.asyncio
+async def test_get_me():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        # First login to get the token
+        login_response = await ac.post(
+            "/api/auth/login",
+            json={"username": "trader", "password": "trader123"},
+        )
+        token = login_response.json()["access_token"]
+
+        # Then get me
+        response = await ac.get(
+            "/api/auth/me",
+            headers={"Authorization": f"Bearer {token}"}
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == TRADER_USER_ID
+    assert data["role"] == "trader"
+
+@pytest.mark.asyncio
+async def test_logout():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        # First login to get the token
+        login_response = await ac.post(
+            "/api/auth/login",
+            json={"username": "trader", "password": "trader123"},
+        )
+        token = login_response.json()["access_token"]
+
+        # Then logout
+        response = await ac.post(
+            "/api/auth/logout",
+            headers={"Authorization": f"Bearer {token}"}
+        )
+        assert response.status_code == 200
+        assert response.json() == {"message": "Logged out successfully"}
+
+        # Trying to use the token again should fail
+        me_response = await ac.get(
+            "/api/auth/me",
+            headers={"Authorization": f"Bearer {token}"}
+        )
+        assert me_response.status_code == 401
+        assert me_response.json() == {"detail": "Token has been revoked"}

--- a/backend/tests/services/test_auth.py
+++ b/backend/tests/services/test_auth.py
@@ -1,0 +1,108 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+from app.services.auth import (
+    hash_password,
+    verify_password,
+    hash_password_sync,
+    verify_password_sync,
+    ldap_authenticate,
+    create_access_token,
+    create_refresh_token,
+    decode_token,
+    invalidate_token,
+    token_blacklist,
+)
+from jose import jwt, JWTError
+
+@pytest.mark.asyncio
+async def test_hash_and_verify_password():
+    password = "test_password_123"
+
+    hashed = await hash_password(password)
+    assert hashed != password
+    assert isinstance(hashed, str)
+
+    is_valid = await verify_password(password, hashed)
+    assert is_valid is True
+
+    is_invalid = await verify_password("wrong_password", hashed)
+    assert is_invalid is False
+
+def test_hash_and_verify_password_sync():
+    password = "test_password_123"
+
+    hashed = hash_password_sync(password)
+    assert hashed != password
+    assert isinstance(hashed, str)
+
+    is_valid = verify_password_sync(password, hashed)
+    assert is_valid is True
+
+@pytest.mark.asyncio
+async def test_ldap_authenticate_success():
+    with patch("ldap3.Server"), \
+         patch("ldap3.Connection") as mock_conn:
+
+        mock_entry = MagicMock(uid="jdoe", mail="jdoe@example.com", cn="John Doe")
+
+        mock_instance = mock_conn.return_value
+        mock_instance.entries = [mock_entry]
+
+        result = await ldap_authenticate("jdoe", "password123")
+
+        assert result is not None
+        assert result["username"] == "jdoe"
+        assert result["email"] == "jdoe@example.com"
+        assert result["display_name"] == "John Doe"
+
+@pytest.mark.asyncio
+async def test_ldap_authenticate_failure():
+    with patch("ldap3.Server"), \
+         patch("ldap3.Connection") as mock_conn:
+
+        mock_instance = mock_conn.return_value
+        mock_instance.entries = []
+
+        result = await ldap_authenticate("jdoe", "wrong_password")
+
+        assert result is None
+
+@pytest.mark.asyncio
+async def test_jwt_tokens():
+    user_id = "test_user_id"
+    role = "trader"
+
+    access_token = create_access_token(user_id, role)
+    refresh_token = create_refresh_token(user_id)
+
+    assert isinstance(access_token, str)
+    assert isinstance(refresh_token, str)
+
+    decoded_access = decode_token(access_token)
+    assert decoded_access["sub"] == user_id
+    assert decoded_access["role"] == role
+    assert decoded_access["type"] == "access"
+
+    decoded_refresh = decode_token(refresh_token)
+    assert decoded_refresh["sub"] == user_id
+    assert decoded_refresh["type"] == "refresh"
+
+@pytest.mark.asyncio
+async def test_invalidate_token():
+    token_blacklist.clear()
+
+    user_id = "test_user_id"
+    role = "trader"
+    token = create_access_token(user_id, role)
+
+    decode_token(token)  # Should not raise
+
+    await invalidate_token(token)
+
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as exc_info:
+        decode_token(token)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Token has been revoked"


### PR DESCRIPTION
This PR modernizes the authentication service (`backend/app/services/auth.py` and `backend/app/api/routes/auth.py`) by resolving synchronous blocking bottlenecks using `asyncio.to_thread`. It introduces centralized, mirror-structured unit tests (`tests/services/test_auth.py` and `tests/api/routes/test_auth_routes.py`) to guarantee high test coverage with `pytest` and `httpx.AsyncClient`. Finally, Pydantic v2 documentation metrics are fulfilled.

---
*PR created automatically by Jules for task [12532027552110036758](https://jules.google.com/task/12532027552110036758) started by @ryzhiy-kot*