### PR TITLE
Refactor auth service for async integrity and test coverage

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -12,6 +12,7 @@ from ...services.auth import (
     decode_token,
     get_current_user,
     hash_password,
+    hash_password_sync,
     invalidate_token,
     ldap_authenticate,
     verify_password,
@@ -32,7 +33,7 @@ MOCK_USERS = {
         "email": "admin@company.com",
         "display_name": "Admin User",
         "role": "admin",
-        "password_hash": hash_password("admin123"),
+        "password_hash": hash_password_sync("admin123"),
         "is_active": True,
     },
     "trader": {
@@ -40,13 +41,18 @@ MOCK_USERS = {
         "email": "trader@company.com",
         "display_name": "Jane Trader",
         "role": "trader",
-        "password_hash": hash_password("trader123"),
+        "password_hash": hash_password_sync("trader123"),
         "is_active": True,
     },
 }
 
 
-@router.post("/login", response_model=TokenResponse)
+@router.post(
+    "/login",
+    response_model=TokenResponse,
+    summary="Login",
+    description="Authenticate user and return a token",
+)
 async def login(request: LoginRequest):
     # Try LDAP first, fallback to mock users
     ldap_user = await ldap_authenticate(request.username, request.password)
@@ -60,7 +66,8 @@ async def login(request: LoginRequest):
         }
     elif request.username in MOCK_USERS:
         user_data = MOCK_USERS[request.username]
-        if not verify_password(request.password, user_data["password_hash"]):
+        is_valid = await verify_password(request.password, user_data["password_hash"])
+        if not is_valid:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"
             )
@@ -79,7 +86,12 @@ async def login(request: LoginRequest):
     )
 
 
-@router.post("/refresh", response_model=TokenResponse)
+@router.post(
+    "/refresh",
+    response_model=TokenResponse,
+    summary="Refresh Token",
+    description="Refresh user access token",
+)
 async def refresh_token(refresh_token: str):
     payload = decode_token(refresh_token)
     if payload.get("type") != "refresh":
@@ -105,7 +117,12 @@ async def refresh_token(refresh_token: str):
     )
 
 
-@router.get("/me", response_model=UserResponse)
+@router.get(
+    "/me",
+    response_model=UserResponse,
+    summary="Get Current User",
+    description="Fetch current user details",
+)
 async def get_me(current_user: dict = Depends(get_current_user)):
     user_id = current_user["sub"]
     for u in MOCK_USERS.values():
@@ -121,7 +138,12 @@ async def get_me(current_user: dict = Depends(get_current_user)):
     raise HTTPException(status_code=404, detail="User not found")
 
 
-@router.post("/logout")
+@router.post(
+    "/logout",
+    response_model=dict,
+    summary="Logout",
+    description="Invalidate current access token",
+)
 async def logout(credentials: HTTPAuthorizationCredentials = Depends(security)):
     invalidate_token(credentials.credentials)
     return {"message": "Logged out successfully"}

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import UTC, datetime, timedelta
 
 import bcrypt
@@ -51,34 +52,54 @@ async def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(s
     return payload
 
 
-def hash_password(password: str) -> str:
+def hash_password_sync(password: str) -> str:
     return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
 
 
-def verify_password(plain_password: str, hashed_password: str) -> bool:
+def verify_password_sync(plain_password: str, hashed_password: str) -> bool:
     return bcrypt.checkpw(plain_password.encode("utf-8"), hashed_password.encode("utf-8"))
+
+
+async def hash_password(password: str) -> str:
+    return await asyncio.to_thread(hash_password_sync, password)
+
+
+async def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return await asyncio.to_thread(verify_password_sync, plain_password, hashed_password)
+
+
+def _ldap_bind_and_search(server, user_dn, password, username, search_base):
+    from ldap3 import Connection
+    conn = Connection(
+        server,
+        user=f"{user_dn},{search_base}",
+        password=password,
+        auto_bind=True,
+    )
+    conn.search(
+        search_base,
+        f"(uid={username})",
+        attributes=["mail", "cn", "uid"],
+    )
+    return conn
 
 
 async def ldap_authenticate(username: str, password: str) -> dict | None:
     """Authenticate against LDAP server. Returns user info dict or None."""
     try:
-        from ldap3 import ALL, Connection, Server
+        from ldap3 import ALL, Server
 
         server = Server(settings.LDAP_SERVER, get_info=ALL)
         user_dn = settings.LDAP_USER_SEARCH_FILTER.format(username=username)
 
-        # Try to bind with user credentials
-        conn = Connection(
+        # Try to bind with user credentials and search, executed in thread
+        conn = await asyncio.to_thread(
+            _ldap_bind_and_search,
             server,
-            user=f"{user_dn},{settings.LDAP_USER_SEARCH_BASE}",
-            password=password,
-            auto_bind=True,
-        )
-
-        conn.search(
+            user_dn,
+            password,
+            username,
             settings.LDAP_USER_SEARCH_BASE,
-            f"(uid={username})",
-            attributes=["mail", "cn", "uid"],
         )
 
         if not conn.entries:

--- a/backend/tests/api/test_auth_routes.py
+++ b/backend/tests/api/test_auth_routes.py
@@ -1,0 +1,115 @@
+import pytest
+import httpx
+from fastapi import FastAPI
+from app.main import app
+from app.config import get_settings
+
+settings = get_settings()
+
+from httpx import ASGITransport
+
+@pytest.fixture
+async def async_client():
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver" + settings.API_PREFIX) as client:
+        yield client
+
+@pytest.mark.asyncio
+async def test_login_success(async_client):
+    # Test valid credentials for mock user
+    response = await async_client.post(
+        "/auth/login",
+        json={"username": "trader", "password": "trader123"}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "access_token" in data
+    assert "refresh_token" in data
+    assert data["token_type"] == "bearer"
+
+@pytest.mark.asyncio
+async def test_login_failure(async_client):
+    # Test invalid credentials
+    response = await async_client.post(
+        "/auth/login",
+        json={"username": "trader", "password": "wrongpassword"}
+    )
+    assert response.status_code == 401
+    data = response.json()
+    assert data["detail"] == "Invalid credentials"
+
+@pytest.mark.asyncio
+async def test_get_me(async_client):
+    # First login to get a token
+    login_response = await async_client.post(
+        "/auth/login",
+        json={"username": "trader", "password": "trader123"}
+    )
+    token = login_response.json()["access_token"]
+
+    # Use token to fetch /me
+    response = await async_client.get(
+        "/auth/me",
+        headers={"Authorization": f"Bearer {token}"}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["email"] == "trader@company.com"
+    assert data["role"] == "trader"
+
+@pytest.mark.asyncio
+async def test_get_me_unauthorized(async_client):
+    # Test accessing without a valid token
+    response = await async_client.get(
+        "/auth/me",
+        headers={"Authorization": "Bearer invalidtoken"}
+    )
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid token"
+
+@pytest.mark.asyncio
+async def test_refresh_token(async_client):
+    # Login to get refresh token
+    login_response = await async_client.post(
+        "/auth/login",
+        json={"username": "trader", "password": "trader123"}
+    )
+    refresh_token = login_response.json()["refresh_token"]
+
+    # Call refresh endpoint with it
+    refresh_response = await async_client.post(
+        "/auth/refresh",
+        params={"refresh_token": refresh_token}
+    )
+    assert refresh_response.status_code == 200
+    data = refresh_response.json()
+    assert "access_token" in data
+    assert "refresh_token" in data
+    # Depending on timing, the new refresh token might be identical or different.
+    # But we ensure it is a valid token structure.
+    assert len(data["refresh_token"]) > 0
+
+@pytest.mark.asyncio
+async def test_logout(async_client):
+    # Login to get token
+    login_response = await async_client.post(
+        "/auth/login",
+        json={"username": "trader", "password": "trader123"}
+    )
+    token = login_response.json()["access_token"]
+
+    # Call logout
+    logout_response = await async_client.post(
+        "/auth/logout",
+        headers={"Authorization": f"Bearer {token}"}
+    )
+    assert logout_response.status_code == 200
+    assert logout_response.json() == {"message": "Logged out successfully"}
+
+    # Calling /me after logout should fail because token was invalidated
+    me_response = await async_client.get(
+        "/auth/me",
+        headers={"Authorization": f"Bearer {token}"}
+    )
+    assert me_response.status_code == 401
+    assert me_response.json()["detail"] == "Token has been revoked"

--- a/backend/tests/services/test_auth.py
+++ b/backend/tests/services/test_auth.py
@@ -1,0 +1,77 @@
+import pytest
+from jose import jwt
+from datetime import datetime, UTC, timedelta
+from app.services.auth import (
+    hash_password,
+    verify_password,
+    create_access_token,
+    create_refresh_token,
+    decode_token,
+    invalidate_token,
+    ldap_authenticate,
+    token_blacklist,
+)
+from app.config import get_settings
+from fastapi import HTTPException, status
+
+settings = get_settings()
+
+@pytest.mark.asyncio
+async def test_password_hashing():
+    password = "secretpassword"
+    hashed = await hash_password(password)
+    assert hashed != password
+    assert await verify_password(password, hashed) is True
+    assert await verify_password("wrongpassword", hashed) is False
+
+def test_create_access_token():
+    user_id = "test-user-id"
+    role = "trader"
+    token = create_access_token(user_id, role)
+    assert token is not None
+
+    payload = decode_token(token)
+    assert payload["sub"] == user_id
+    assert payload["role"] == role
+    assert payload["type"] == "access"
+
+def test_create_refresh_token():
+    user_id = "test-user-id"
+    token = create_refresh_token(user_id)
+    assert token is not None
+
+    payload = decode_token(token)
+    assert payload["sub"] == user_id
+    assert payload["type"] == "refresh"
+    assert "role" not in payload
+
+def test_decode_invalid_token():
+    with pytest.raises(HTTPException) as excinfo:
+        decode_token("invalid_token_string")
+    assert excinfo.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert excinfo.value.detail == "Invalid token"
+
+def test_invalidate_token():
+    user_id = "test-user-id"
+    token = create_access_token(user_id, "trader")
+
+    # Valid token should be decoded successfully
+    payload = decode_token(token)
+    assert payload["sub"] == user_id
+
+    # Invalidate token
+    invalidate_token(token)
+    assert token in token_blacklist
+
+    # Decoded invalidated token should raise HTTPException
+    with pytest.raises(HTTPException) as excinfo:
+        decode_token(token)
+    assert excinfo.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert excinfo.value.detail == "Token has been revoked"
+
+@pytest.mark.asyncio
+async def test_ldap_authenticate_failure():
+    # Attempting to authenticate with invalid credentials or missing LDAP server
+    # should return None
+    result = await ldap_authenticate("wronguser", "wrongpassword")
+    assert result is None


### PR DESCRIPTION
Modernizes the auth service and routes to adhere to strict async-safety, typing, and testing guidelines. CPU-bound and I/O-bound synchronous calls from `bcrypt` and `ldap3` are now properly segregated to worker threads. Added clear documentation schemas to the endpoints, and built out a full ASGITransport testing suite.

---
*PR created automatically by Jules for task [2572002200369516108](https://jules.google.com/task/2572002200369516108) started by @ryzhiy-kot*