### PR TITLE
Refactor Authentication Service for Async Integrity

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -26,13 +26,14 @@ TRADER_USER_ID = "550e8400-e29b-41d4-a716-446655440000"
 ADMIN_USER_ID = "550e8400-e29b-41d4-a716-446655440001"
 
 # In-memory user store for mock mode (replace with DB in production)
+# Pre-computed bcrypt hashes to avoid blocking module initialization
 MOCK_USERS = {
     "admin": {
         "id": ADMIN_USER_ID,
         "email": "admin@company.com",
         "display_name": "Admin User",
         "role": "admin",
-        "password_hash": hash_password("admin123"),
+        "password_hash": "$2b$12$1ftfcDzHB7yTiBMm3aE1QuJRoMywL4UyQ/IDnc/ZFQQBgE5Fh71uK",
         "is_active": True,
     },
     "trader": {
@@ -40,13 +41,13 @@ MOCK_USERS = {
         "email": "trader@company.com",
         "display_name": "Jane Trader",
         "role": "trader",
-        "password_hash": hash_password("trader123"),
+        "password_hash": "$2b$12$aNmlsLp7yEAbei8os8DJyO4dg9UpnAfq3d9C7WRcCeqFdwE5uOsZu",
         "is_active": True,
     },
 }
 
 
-@router.post("/login", response_model=TokenResponse)
+@router.post("/login", response_model=TokenResponse, summary="User Login", description="Authenticate a user and return access and refresh tokens.")
 async def login(request: LoginRequest):
     # Try LDAP first, fallback to mock users
     ldap_user = await ldap_authenticate(request.username, request.password)
@@ -60,7 +61,8 @@ async def login(request: LoginRequest):
         }
     elif request.username in MOCK_USERS:
         user_data = MOCK_USERS[request.username]
-        if not verify_password(request.password, user_data["password_hash"]):
+        is_valid = await verify_password(request.password, user_data["password_hash"])
+        if not is_valid:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"
             )
@@ -69,8 +71,8 @@ async def login(request: LoginRequest):
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"
         )
 
-    access_token = create_access_token(user_data["id"], user_data["role"])
-    refresh_token = create_refresh_token(user_data["id"])
+    access_token = await create_access_token(user_data["id"], user_data["role"])
+    refresh_token = await create_refresh_token(user_data["id"])
 
     return TokenResponse(
         access_token=access_token,
@@ -79,9 +81,9 @@ async def login(request: LoginRequest):
     )
 
 
-@router.post("/refresh", response_model=TokenResponse)
+@router.post("/refresh", response_model=TokenResponse, summary="Refresh Token", description="Exchange a refresh token for a new access token.")
 async def refresh_token(refresh_token: str):
-    payload = decode_token(refresh_token)
+    payload = await decode_token(refresh_token)
     if payload.get("type") != "refresh":
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid refresh token"
@@ -95,8 +97,8 @@ async def refresh_token(refresh_token: str):
             role = u["role"]
             break
 
-    access_token = create_access_token(user_id, role)
-    new_refresh_token = create_refresh_token(user_id)
+    access_token = await create_access_token(user_id, role)
+    new_refresh_token = await create_refresh_token(user_id)
 
     return TokenResponse(
         access_token=access_token,
@@ -105,7 +107,7 @@ async def refresh_token(refresh_token: str):
     )
 
 
-@router.get("/me", response_model=UserResponse)
+@router.get("/me", response_model=UserResponse, summary="Get Current User", description="Get the currently authenticated user's profile.")
 async def get_me(current_user: dict = Depends(get_current_user)):
     user_id = current_user["sub"]
     for u in MOCK_USERS.values():
@@ -121,7 +123,7 @@ async def get_me(current_user: dict = Depends(get_current_user)):
     raise HTTPException(status_code=404, detail="User not found")
 
 
-@router.post("/logout")
+@router.post("/logout", response_model=dict, summary="User Logout", description="Invalidate the current access token.")
 async def logout(credentials: HTTPAuthorizationCredentials = Depends(security)):
     invalidate_token(credentials.credentials)
     return {"message": "Logged out successfully"}

--- a/backend/app/api/websocket/__init__.py
+++ b/backend/app/api/websocket/__init__.py
@@ -25,7 +25,7 @@ async def websocket_panel_stream(websocket: WebSocket, panel_id: str, token: str
         return
     
     try:
-        current_user = decode_token(token)
+        current_user = await decode_token(token)
     except Exception:
         await websocket.close(code=4001, reason="Invalid or expired token")
         return

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import UTC, datetime, timedelta
 
 import bcrypt
@@ -14,23 +15,23 @@ security = HTTPBearer()
 token_blacklist: set[str] = set()
 
 
-def create_access_token(user_id: str, role: str) -> str:
+async def create_access_token(user_id: str, role: str) -> str:
     expire = datetime.now(UTC) + timedelta(minutes=settings.JWT_ACCESS_TOKEN_EXPIRE_MINUTES)
     payload = {"sub": user_id, "role": role, "exp": expire, "type": "access"}
-    return jwt.encode(payload, settings.SECRET_KEY, algorithm=settings.JWT_ALGORITHM)
+    return await asyncio.to_thread(jwt.encode, payload, settings.SECRET_KEY, algorithm=settings.JWT_ALGORITHM)
 
 
-def create_refresh_token(user_id: str) -> str:
+async def create_refresh_token(user_id: str) -> str:
     expire = datetime.now(UTC) + timedelta(days=settings.JWT_REFRESH_TOKEN_EXPIRE_DAYS)
     payload = {"sub": user_id, "exp": expire, "type": "refresh"}
-    return jwt.encode(payload, settings.SECRET_KEY, algorithm=settings.JWT_ALGORITHM)
+    return await asyncio.to_thread(jwt.encode, payload, settings.SECRET_KEY, algorithm=settings.JWT_ALGORITHM)
 
 
-def decode_token(token: str) -> dict:
+async def decode_token(token: str) -> dict:
     if token in token_blacklist:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token has been revoked")
     try:
-        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.JWT_ALGORITHM])
+        payload = await asyncio.to_thread(jwt.decode, token, settings.SECRET_KEY, algorithms=[settings.JWT_ALGORITHM])
         return payload
     except JWTError:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
@@ -45,18 +46,25 @@ def invalidate_token(token: str) -> None:
 
 
 async def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(security)) -> dict:
-    payload = decode_token(credentials.credentials)
+    payload = await decode_token(credentials.credentials)
     if payload.get("type") != "access":
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token type")
     return payload
 
 
-def hash_password(password: str) -> str:
-    return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+async def hash_password(password: str) -> str:
+    def _hash() -> bytes:
+        return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt())
+
+    hashed = await asyncio.to_thread(_hash)
+    return hashed.decode("utf-8")
 
 
-def verify_password(plain_password: str, hashed_password: str) -> bool:
-    return bcrypt.checkpw(plain_password.encode("utf-8"), hashed_password.encode("utf-8"))
+async def verify_password(plain_password: str, hashed_password: str) -> bool:
+    def _verify() -> bool:
+        return bcrypt.checkpw(plain_password.encode("utf-8"), hashed_password.encode("utf-8"))
+
+    return await asyncio.to_thread(_verify)
 
 
 async def ldap_authenticate(username: str, password: str) -> dict | None:
@@ -67,26 +75,32 @@ async def ldap_authenticate(username: str, password: str) -> dict | None:
         server = Server(settings.LDAP_SERVER, get_info=ALL)
         user_dn = settings.LDAP_USER_SEARCH_FILTER.format(username=username)
 
-        # Try to bind with user credentials
-        conn = Connection(
-            server,
-            user=f"{user_dn},{settings.LDAP_USER_SEARCH_BASE}",
-            password=password,
-            auto_bind=True,
-        )
+        def _ldap_operations():
+            # Try to bind with user credentials
+            conn = Connection(
+                server,
+                user=f"{user_dn},{settings.LDAP_USER_SEARCH_BASE}",
+                password=password,
+                auto_bind=True,
+            )
 
-        conn.search(
-            settings.LDAP_USER_SEARCH_BASE,
-            f"(uid={username})",
-            attributes=["mail", "cn", "uid"],
-        )
+            conn.search(
+                settings.LDAP_USER_SEARCH_BASE,
+                f"(uid={username})",
+                attributes=["mail", "cn", "uid"],
+            )
 
-        if not conn.entries:
+            if not conn.entries:
+                conn.unbind()
+                return None
+
+            entry = conn.entries[0]
             conn.unbind()
-            return None
+            return entry
 
-        entry = conn.entries[0]
-        conn.unbind()
+        entry = await asyncio.to_thread(_ldap_operations)
+        if not entry:
+            return None
 
         return {
             "username": str(entry.uid) if hasattr(entry, "uid") else username,

--- a/backend/tests/services/test_auth.py
+++ b/backend/tests/services/test_auth.py
@@ -1,0 +1,173 @@
+import pytest
+import asyncio
+from unittest.mock import patch, MagicMock
+from fastapi import FastAPI, Depends, HTTPException, status
+from httpx import AsyncClient, ASGITransport
+from jose import JWTError, jwt
+
+from app.services.auth import (
+    create_access_token,
+    create_refresh_token,
+    decode_token,
+    get_current_user,
+    hash_password,
+    verify_password,
+    ldap_authenticate,
+    token_blacklist,
+    settings,
+)
+
+# Mock app for integration testing of dependency injection
+app = FastAPI()
+
+@app.get("/secure-data")
+async def secure_endpoint(user: dict = Depends(get_current_user)):
+    return {"message": "secure data", "user_id": user["sub"]}
+
+@pytest.mark.asyncio
+async def test_password_hashing_and_verification():
+    password = "supersecretpassword"
+    hashed = await hash_password(password)
+
+    assert hashed != password
+    assert isinstance(hashed, str)
+
+    is_valid = await verify_password(password, hashed)
+    assert is_valid is True
+
+    is_invalid = await verify_password("wrongpassword", hashed)
+    assert is_invalid is False
+
+
+@pytest.mark.asyncio
+async def test_jwt_token_generation_and_decoding():
+    user_id = "test-user-123"
+    role = "trader"
+
+    # Test Access Token
+    access_token = await create_access_token(user_id, role)
+    assert isinstance(access_token, str)
+
+    decoded_access = await decode_token(access_token)
+    assert decoded_access["sub"] == user_id
+    assert decoded_access["role"] == role
+    assert decoded_access["type"] == "access"
+    assert "exp" in decoded_access
+
+    # Test Refresh Token
+    refresh_token = await create_refresh_token(user_id)
+    assert isinstance(refresh_token, str)
+
+    decoded_refresh = await decode_token(refresh_token)
+    assert decoded_refresh["sub"] == user_id
+    assert decoded_refresh["type"] == "refresh"
+    assert "role" not in decoded_refresh
+    assert "exp" in decoded_refresh
+
+
+@pytest.mark.asyncio
+async def test_decode_invalid_token():
+    with pytest.raises(HTTPException) as excinfo:
+        await decode_token("invalid.token.here")
+
+    assert excinfo.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert excinfo.value.detail == "Invalid token"
+
+
+@pytest.mark.asyncio
+async def test_decode_revoked_token():
+    user_id = "test-user"
+    token = await create_access_token(user_id, "admin")
+
+    # Revoke token
+    token_blacklist.add(token)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await decode_token(token)
+
+    assert excinfo.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert excinfo.value.detail == "Token has been revoked"
+
+    # Cleanup
+    token_blacklist.remove(token)
+
+
+@pytest.mark.asyncio
+async def test_ldap_authenticate_success():
+    with patch("ldap3.Connection") as MockConnection:
+        # Mock LDAP connection and entry
+        mock_conn = MagicMock()
+        MockConnection.return_value = mock_conn
+
+        mock_entry = MagicMock()
+        mock_entry.uid = "jdoe"
+        mock_entry.mail = "jdoe@example.com"
+        mock_entry.cn = "John Doe"
+
+        mock_conn.entries = [mock_entry]
+
+        result = await ldap_authenticate("jdoe", "password123")
+
+        assert result is not None
+        assert result["username"] == "jdoe"
+        assert result["email"] == "jdoe@example.com"
+        assert result["display_name"] == "John Doe"
+
+
+@pytest.mark.asyncio
+async def test_ldap_authenticate_failure():
+    with patch("ldap3.Connection") as MockConnection:
+        # Mock LDAP connection with no entries (failed search/bind)
+        mock_conn = MagicMock()
+        MockConnection.return_value = mock_conn
+        mock_conn.entries = []
+
+        result = await ldap_authenticate("invalid", "wrongpass")
+
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_dependency_injection_success():
+    user_id = "test-user-id"
+    token = await create_access_token(user_id, "admin")
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            "/secure-data", headers={"Authorization": f"Bearer {token}"}
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["message"] == "secure data"
+    assert data["user_id"] == user_id
+
+
+@pytest.mark.asyncio
+async def test_dependency_injection_missing_token():
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/secure-data")
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Not authenticated"}
+
+
+@pytest.mark.asyncio
+async def test_dependency_injection_invalid_token_type():
+    user_id = "test-user-id"
+    # Create refresh token instead of access token
+    token = await create_refresh_token(user_id)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            "/secure-data", headers={"Authorization": f"Bearer {token}"}
+        )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Invalid token type"}


### PR DESCRIPTION
Modernized the authentication service module `backend/app/services/auth.py` and its routes to achieve strict asynchronous integrity. Blocking CPU/Network-bound functions (like `bcrypt.hashpw`, `jwt.encode`, and LDAP operations) have been correctly shifted to `asyncio.to_thread`. Module-level dictionaries in routes have been optimized with pre-computed hashes. A full centralized test suite mirroring the app directory has been provided at `tests/services/test_auth.py`, complete with `Depends` injection testing via `httpx.AsyncClient`. All auth API endpoints have been formally documented per OpenAPI standards.

---
*PR created automatically by Jules for task [3387436130370419634](https://jules.google.com/task/3387436130370419634) started by @ryzhiy-kot*