### PR TITLE
Refactor authentication services for async event loop safety

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -32,7 +32,7 @@ MOCK_USERS = {
         "email": "admin@company.com",
         "display_name": "Admin User",
         "role": "admin",
-        "password_hash": hash_password("admin123"),
+        "password_hash": "$2b$12$8H8p.XgX4TfBcEclxEUTFeXrYxj66zPlj84AiF9LWQ/h1vRAUtscW",
         "is_active": True,
     },
     "trader": {
@@ -40,13 +40,18 @@ MOCK_USERS = {
         "email": "trader@company.com",
         "display_name": "Jane Trader",
         "role": "trader",
-        "password_hash": hash_password("trader123"),
+        "password_hash": "$2b$12$B8S8ZnzCZ.DkRNZxDOfWK.L3t6UA1whTZMRxNGeRVfooSZzZCS3Py",
         "is_active": True,
     },
 }
 
 
-@router.post("/login", response_model=TokenResponse)
+@router.post(
+    "/login",
+    response_model=TokenResponse,
+    summary="Login user",
+    description="Authenticates a user via LDAP or mock store and returns JWT tokens.",
+)
 async def login(request: LoginRequest):
     # Try LDAP first, fallback to mock users
     ldap_user = await ldap_authenticate(request.username, request.password)
@@ -60,7 +65,8 @@ async def login(request: LoginRequest):
         }
     elif request.username in MOCK_USERS:
         user_data = MOCK_USERS[request.username]
-        if not verify_password(request.password, user_data["password_hash"]):
+        is_valid = await verify_password(request.password, user_data["password_hash"])
+        if not is_valid:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"
             )
@@ -79,7 +85,12 @@ async def login(request: LoginRequest):
     )
 
 
-@router.post("/refresh", response_model=TokenResponse)
+@router.post(
+    "/refresh",
+    response_model=TokenResponse,
+    summary="Refresh access token",
+    description="Issues a new access token using a valid refresh token.",
+)
 async def refresh_token(refresh_token: str):
     payload = decode_token(refresh_token)
     if payload.get("type") != "refresh":
@@ -105,7 +116,12 @@ async def refresh_token(refresh_token: str):
     )
 
 
-@router.get("/me", response_model=UserResponse)
+@router.get(
+    "/me",
+    response_model=UserResponse,
+    summary="Get current user",
+    description="Returns the currently authenticated user's profile details.",
+)
 async def get_me(current_user: dict = Depends(get_current_user)):
     user_id = current_user["sub"]
     for u in MOCK_USERS.values():
@@ -121,7 +137,12 @@ async def get_me(current_user: dict = Depends(get_current_user)):
     raise HTTPException(status_code=404, detail="User not found")
 
 
-@router.post("/logout")
+@router.post(
+    "/logout",
+    response_model=dict,
+    summary="Logout user",
+    description="Invalidates the current user's access token.",
+)
 async def logout(credentials: HTTPAuthorizationCredentials = Depends(security)):
     invalidate_token(credentials.credentials)
     return {"message": "Logged out successfully"}

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import UTC, datetime, timedelta
 
 import bcrypt
@@ -51,47 +52,55 @@ async def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(s
     return payload
 
 
-def hash_password(password: str) -> str:
-    return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+async def hash_password(password: str) -> str:
+    return await asyncio.to_thread(
+        lambda: bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+    )
 
 
-def verify_password(plain_password: str, hashed_password: str) -> bool:
-    return bcrypt.checkpw(plain_password.encode("utf-8"), hashed_password.encode("utf-8"))
+async def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return await asyncio.to_thread(
+        lambda: bcrypt.checkpw(plain_password.encode("utf-8"), hashed_password.encode("utf-8"))
+    )
+
+
+def _ldap_sync(username: str, password: str) -> dict | None:
+    from ldap3 import ALL, Connection, Server
+
+    server = Server(settings.LDAP_SERVER, get_info=ALL)
+    user_dn = settings.LDAP_USER_SEARCH_FILTER.format(username=username)
+
+    # Try to bind with user credentials
+    conn = Connection(
+        server,
+        user=f"{user_dn},{settings.LDAP_USER_SEARCH_BASE}",
+        password=password,
+        auto_bind=True,
+    )
+
+    conn.search(
+        settings.LDAP_USER_SEARCH_BASE,
+        f"(uid={username})",
+        attributes=["mail", "cn", "uid"],
+    )
+
+    if not conn.entries:
+        conn.unbind()
+        return None
+
+    entry = conn.entries[0]
+    conn.unbind()
+
+    return {
+        "username": str(entry.uid) if hasattr(entry, "uid") else username,
+        "email": str(entry.mail) if hasattr(entry, "mail") else f"{username}@company.com",
+        "display_name": str(entry.cn) if hasattr(entry, "cn") else username,
+    }
 
 
 async def ldap_authenticate(username: str, password: str) -> dict | None:
     """Authenticate against LDAP server. Returns user info dict or None."""
     try:
-        from ldap3 import ALL, Connection, Server
-
-        server = Server(settings.LDAP_SERVER, get_info=ALL)
-        user_dn = settings.LDAP_USER_SEARCH_FILTER.format(username=username)
-
-        # Try to bind with user credentials
-        conn = Connection(
-            server,
-            user=f"{user_dn},{settings.LDAP_USER_SEARCH_BASE}",
-            password=password,
-            auto_bind=True,
-        )
-
-        conn.search(
-            settings.LDAP_USER_SEARCH_BASE,
-            f"(uid={username})",
-            attributes=["mail", "cn", "uid"],
-        )
-
-        if not conn.entries:
-            conn.unbind()
-            return None
-
-        entry = conn.entries[0]
-        conn.unbind()
-
-        return {
-            "username": str(entry.uid) if hasattr(entry, "uid") else username,
-            "email": str(entry.mail) if hasattr(entry, "mail") else f"{username}@company.com",
-            "display_name": str(entry.cn) if hasattr(entry, "cn") else username,
-        }
+        return await asyncio.to_thread(_ldap_sync, username, password)
     except Exception:
         return None

--- a/backend/tests/api/routes/test_auth_routes.py
+++ b/backend/tests/api/routes/test_auth_routes.py
@@ -1,0 +1,116 @@
+import pytest
+from httpx import ASGITransport, AsyncClient
+from app.main import app
+from app.api.routes.auth import TRADER_USER_ID, ADMIN_USER_ID
+
+
+@pytest.fixture
+async def async_client():
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test/api"
+    ) as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_login_success_mock_user(async_client):
+    response = await async_client.post(
+        "/auth/login",
+        json={"username": "trader", "password": "trader123"}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "access_token" in data
+    assert "refresh_token" in data
+    assert data["token_type"] == "bearer"
+
+
+@pytest.mark.asyncio
+async def test_login_failure_wrong_password(async_client):
+    response = await async_client.post(
+        "/auth/login",
+        json={"username": "trader", "password": "wrong_password"}
+    )
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Invalid credentials"}
+
+
+@pytest.mark.asyncio
+async def test_login_failure_unknown_user(async_client):
+    response = await async_client.post(
+        "/auth/login",
+        json={"username": "unknown", "password": "password"}
+    )
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Invalid credentials"}
+
+
+@pytest.mark.asyncio
+async def test_refresh_token(async_client):
+    # First login to get a refresh token
+    login_res = await async_client.post(
+        "/auth/login",
+        json={"username": "trader", "password": "trader123"}
+    )
+    assert login_res.status_code == 200
+    refresh_token = login_res.json()["refresh_token"]
+
+    # Use refresh token to get new tokens
+    refresh_res = await async_client.post(
+        "/auth/refresh",
+        params={"refresh_token": refresh_token}
+    )
+    assert refresh_res.status_code == 200
+    data = refresh_res.json()
+    assert "access_token" in data
+    assert "refresh_token" in data
+
+
+@pytest.mark.asyncio
+async def test_get_me(async_client):
+    # Login to get access token
+    login_res = await async_client.post(
+        "/auth/login",
+        json={"username": "admin", "password": "admin123"}
+    )
+    assert login_res.status_code == 200
+    access_token = login_res.json()["access_token"]
+
+    # Fetch profile
+    me_res = await async_client.get(
+        "/auth/me",
+        headers={"Authorization": f"Bearer {access_token}"}
+    )
+    assert me_res.status_code == 200
+    data = me_res.json()
+    assert data["id"] == ADMIN_USER_ID
+    assert data["email"] == "admin@company.com"
+    assert data["role"] == "admin"
+
+
+@pytest.mark.asyncio
+async def test_logout(async_client):
+    # Login to get access token
+    login_res = await async_client.post(
+        "/auth/login",
+        json={"username": "trader", "password": "trader123"}
+    )
+    assert login_res.status_code == 200
+    access_token = login_res.json()["access_token"]
+
+    # Logout
+    logout_res = await async_client.post(
+        "/auth/logout",
+        headers={"Authorization": f"Bearer {access_token}"}
+    )
+    assert logout_res.status_code == 200
+    assert logout_res.json() == {"message": "Logged out successfully"}
+
+    # Try to use access token again (should fail)
+    me_res = await async_client.get(
+        "/auth/me",
+        headers={"Authorization": f"Bearer {access_token}"}
+    )
+    assert me_res.status_code == 401
+    assert me_res.json() == {"detail": "Token has been revoked"}

--- a/backend/tests/services/test_auth.py
+++ b/backend/tests/services/test_auth.py
@@ -1,0 +1,82 @@
+import pytest
+from jose import jwt
+
+from app.services.auth import (
+    create_access_token,
+    create_refresh_token,
+    decode_token,
+    hash_password,
+    invalidate_token,
+    verify_password,
+    token_blacklist,
+)
+from app.config import get_settings
+from fastapi import HTTPException, status
+
+settings = get_settings()
+
+@pytest.mark.asyncio
+async def test_hash_and_verify_password():
+    password = "secret_password"
+    hashed = await hash_password(password)
+
+    # Should verify correctly
+    assert await verify_password(password, hashed) is True
+
+    # Should fail with wrong password
+    assert await verify_password("wrong_password", hashed) is False
+
+
+def test_create_and_decode_access_token():
+    user_id = "test-user-123"
+    role = "trader"
+
+    token = create_access_token(user_id, role)
+    payload = decode_token(token)
+
+    assert payload["sub"] == user_id
+    assert payload["role"] == role
+    assert payload["type"] == "access"
+    assert "exp" in payload
+
+
+def test_create_and_decode_refresh_token():
+    user_id = "test-user-123"
+
+    token = create_refresh_token(user_id)
+    payload = decode_token(token)
+
+    assert payload["sub"] == user_id
+    assert payload["type"] == "refresh"
+    assert "exp" in payload
+
+
+def test_invalidate_token():
+    user_id = "test-user-123"
+    role = "trader"
+
+    token = create_access_token(user_id, role)
+
+    # Ensure token is valid initially
+    decode_token(token)
+
+    # Invalidate token
+    invalidate_token(token)
+
+    # Check if decode fails
+    with pytest.raises(HTTPException) as excinfo:
+        decode_token(token)
+
+    assert excinfo.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert excinfo.value.detail == "Token has been revoked"
+
+    # Clean up token blacklist
+    token_blacklist.clear()
+
+
+def test_decode_invalid_token():
+    with pytest.raises(HTTPException) as excinfo:
+        decode_token("invalid.token.here")
+
+    assert excinfo.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert excinfo.value.detail == "Invalid token"


### PR DESCRIPTION
This submission modernizes the backend authentication module. By offloading CPU-bound tasks like bcrypt hashing and synchronous network calls like ldap3 to separate threads (`asyncio.to_thread`), the event loop is no longer blocked. Endpoints were comprehensively documented, and a full suite of tests leveraging `ASGITransport` was introduced.

---
*PR created automatically by Jules for task [2726862940999273026](https://jules.google.com/task/2726862940999273026) started by @ryzhiy-kot*